### PR TITLE
Single buy confirmations

### DIFF
--- a/lib/bancard.rb
+++ b/lib/bancard.rb
@@ -8,6 +8,8 @@ require 'bancard/single_buy_init'
 require 'bancard/single_buy_init_response'
 require 'bancard/single_buy_rollback'
 require 'bancard/single_buy_rollback_response'
+require 'bancard/single_buy_confirmation'
+require 'bancard/single_buy_confirmation_response'
 require 'bancard/gateway'
 
 module Bancard

--- a/lib/bancard/gateway.rb
+++ b/lib/bancard/gateway.rb
@@ -17,6 +17,11 @@ module Bancard
       submit_single_buy_rollback(rollback)
     end
 
+    def single_buy_confirmation(params = {})
+      confirmation = build_single_buy_confirmation(params)
+      submit_single_buy_confirmation(confirmation)
+    end
+    
     private
 
     def build_single_buy_init(params = {})
@@ -26,7 +31,11 @@ module Bancard
     def build_single_buy_rollback(params = {})
       Bancard::SingleBuyRollback.new(merge_auth_params(params))
     end
-
+    
+    def build_single_buy_confirmation(params = {})
+      Bancard::SingleBuyConfirmation.new(merge_auth_params(params))
+    end
+    
     def submit_single_buy_init(init)
       url      = Bancard.vpos_url(Bancard::SingleBuyInit::ENDPOINT)
       response = Typhoeus.post(url, body: init.request_params.to_json)
@@ -39,6 +48,12 @@ module Bancard
       Bancard::SingleBuyRollbackResponse.new response
     end
 
+    def submit_single_buy_confirmation(confirmation)
+      url      = Bancard.vpos_url(Bancard::SingleBuyConfirmation::ENDPOINT)
+      response = Typhoeus.post(url, body: confirmation.request_params.to_json)
+      Bancard::SingleBuyConfirmationResponse.new response
+    end
+    
     def merge_auth_params(hash)
       hash.merge(public_key: public_key, private_key: private_key)
     end

--- a/lib/bancard/gateway.rb
+++ b/lib/bancard/gateway.rb
@@ -17,7 +17,7 @@ module Bancard
       submit_single_buy_rollback(rollback)
     end
 
-    def single_buy_confirmation(params = {})
+    def confirmation(params = {})
       confirmation = build_single_buy_confirmation(params)
       submit_single_buy_confirmation(confirmation)
     end

--- a/lib/bancard/single_buy_confirmation.rb
+++ b/lib/bancard/single_buy_confirmation.rb
@@ -1,0 +1,38 @@
+module Bancard
+  class SingleBuyConfirmation
+    include Bancard::Utils
+    ENDPOINT = '/vpos/api/0.3/single_buy/confirmations'
+
+    attr_accessor :given_params, :public_key, :private_key
+
+    def initialize(given_params = {})
+      @given_params = stringify_keys(given_params)
+      @public_key   = @given_params.delete('public_key')
+      @private_key  = @given_params.delete('private_key')
+    end
+
+    def request_params
+      {
+        operation:  operation_params,
+        public_key: public_key,
+      }
+    end
+
+    def operation_params
+      {
+        shop_process_id: shop_process_id,
+        token:           token,
+      }
+    end
+
+    private
+
+    def shop_process_id
+      given_params['shop_process_id']
+    end
+
+    def token
+      Digest::MD5.hexdigest [private_key, shop_process_id, 'get_confirmation'].join('')
+    end
+  end
+end

--- a/lib/bancard/single_buy_confirmation_response.rb
+++ b/lib/bancard/single_buy_confirmation_response.rb
@@ -1,0 +1,28 @@
+# works like ActiveMerchant::Billing::Response to maintain compatibility to
+# active merchant gateways
+
+module Bancard
+  class SingleBuyConfirmationResponse
+    attr_reader :body
+
+    def initialize(response)
+      @original_response = response
+      @body              = JSON.parse(response.body)
+    end
+
+    def success?
+      body['status'] == 'success'
+    end
+
+    def params
+      body
+    end
+
+    def process_id
+      body['process_id']
+    end
+
+    def message
+    end
+  end
+end


### PR DESCRIPTION
First than all thank you for your implementation for the Bancard REST API.

There is a new method called get confirmation for a single buy which is required to request the certificate for production. Then I added this new API request according with the structure you have been managing till now.

Thank you,
cesVald